### PR TITLE
fix: prevent model selection failures when API requests fail (#3813, #3874)

### DIFF
--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -94,12 +94,14 @@ export const ModelPicker = ({
 	}, [])
 
 	useEffect(() => {
-		if (!selectedModelId && !isInitialized.current) {
-			const initialValue = modelIds.includes(selectedModelId) ? selectedModelId : defaultModelId
-			setApiConfigurationField(modelIdKey, initialValue)
+		if (!isInitialized.current) {
+			// If no model is selected or the selected model is not in the available models list,
+			// initialize with the default model
+			if (!selectedModelId || !modelIds.includes(selectedModelId)) {
+				setApiConfigurationField(modelIdKey, defaultModelId)
+			}
+			isInitialized.current = true
 		}
-
-		isInitialized.current = true
 	}, [modelIds, setApiConfigurationField, modelIdKey, selectedModelId, defaultModelId])
 
 	return (


### PR DESCRIPTION
This PR fixes issues #3813 and #3874 where users couldn't select models when some provider APIs fail.

Changes:
- Use Promise.allSettled instead of Promise.all to handle provider API failures gracefully
- Fix model initialization logic in ModelPicker component
- Ensures models can be selected even when some provider APIs fail